### PR TITLE
Define grugru-highlight-mode to suppress warning

### DIFF
--- a/grugru.el
+++ b/grugru.el
@@ -5,7 +5,7 @@
 ;; Author: ROCKTAKEY <rocktakey@gmail.com>
 ;; Keywords: convenience, abbrev, tools
 
-;; Version: 1.9.1
+;; Version: 1.9.2
 ;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/ROCKTAKEY/grugru
 

--- a/grugru.el
+++ b/grugru.el
@@ -284,6 +284,9 @@ Each element of GRUGRU-ALIST is (GETTER . STRS-OR-FUNCTION), which is same as
 
 
 ;; For user interaction
+
+(defvar grugru-highlight-mode)
+
 ;;;###autoload
 (defun grugru ()
   "Rotate thing on point, if it is in `grugru-*-grugru-alist'.


### PR DESCRIPTION
To suppress byte-compiler warning, I add grugru-highlight-mode definition.

### before

```
 grugru.…    96   1 error           "." doesn't start with package's prefix "grugru". (emacs-lisp-package)
 grugru.…   325  17 warning         reference to free variable ‘grugru-highlight-mode’ (emacs-lisp)
```

### after
```
 grugru.…    96   1 error           "." doesn't start with package's prefix "grugru". (emacs-lisp-package)
```