### PR TITLE
Use cl-find-if-not instead of eval

### DIFF
--- a/grugru.el
+++ b/grugru.el
@@ -5,7 +5,7 @@
 ;; Author: ROCKTAKEY <rocktakey@gmail.com>
 ;; Keywords: convenience, abbrev, tools
 
-;; Version: 1.9.0
+;; Version: 1.9.1
 ;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/ROCKTAKEY/grugru
 

--- a/grugru.el
+++ b/grugru.el
@@ -280,12 +280,7 @@ Each element of GRUGRU-ALIST is (GETTER . STRS-OR-FUNCTION), which is same as
     (or
      (functionp object)
      (and (listp object)
-          (eval
-           `(and
-             ,@(mapcar
-                (lambda (arg)
-                  `(stringp ',arg))
-                object)))))))
+          (cl-every #'stringp object)))))
 
 
 ;; For user interaction


### PR DESCRIPTION
eval is expensive and should not be used too much.

Since `and` is a special form and cannot be applied,
you can use cl's list function to do the same thing.