### PR TITLE
Add default words for org mode

### DIFF
--- a/grugru-default.el
+++ b/grugru-default.el
@@ -74,7 +74,6 @@ with `grugru-remove-on-major-mode' or `grugru-remove-global'."
     (word "nofnadjust" "fnadjust")
     (word "entitiespretty" "entitiesplain")
     (word "title" "author" "email" "date")
-    (word "todo" "done")
     ;; source block
     ;; TODO
     )))

--- a/grugru-default.el
+++ b/grugru-default.el
@@ -50,7 +50,7 @@ with `grugru-remove-on-major-mode' or `grugru-remove-global'."
     (word   "global" "local"))
    ((tex-mode latex-mode yatex-mode)
     (symbol "figure" "table"))
-   ((org-mode) ;; v9.3.6
+   (org-mode ;; v9.3.6
     (word ":t" ":nil")
     (word "overview" "showall")
     (word "fold" "unfold" "content" "showeverything")

--- a/grugru-default.el
+++ b/grugru-default.el
@@ -49,7 +49,35 @@ with `grugru-remove-on-major-mode' or `grugru-remove-global'."
     (symbol "setq" "setq-default")
     (word   "global" "local"))
    ((tex-mode latex-mode yatex-mode)
-    (symbol "figure" "table"))))
+    (symbol "figure" "table"))
+   ((org-mode) ;; v9.3.6
+    (word ":t" ":nil")
+    (word "overview" "showall")
+    (word "fold" "unfold" "content" "showeverything")
+    (word "indent" "noindent")
+    (word "align" "noalign")
+    (word "inlineimages" "noinlineimages")
+    (word "latexpreview" "nolatexpreview")
+    (word "hideblocks" "showblocks") ;; nohideblocks
+    (word "odd" "oddeven")
+    (word "nologrefile" "logrefile" "lognoterefile")
+    (word "nologdone" "logdone" "lognotedone")
+    (word "nologreschedule" "logreschedule" "lognotereschedule")
+    (word "nologredeadline" "logredeadline" "lognoteredeadline")
+    (word "lognoteclock-out" "nolognoteclock-out")
+    (word "logdrawer" "nologdrawer")
+    (word "logstatesreversed" "nologstatesreversed")
+    (word "nologrepeat" "logrepeat" "lognoterepeat")
+    (word "hidestars" "showstars")
+    (word "fninline" "nofninline" "fnlocal")
+    (word "fnauto" "fnprompt" "fnconfirm" "fnplain") ;; TODO
+    (word "nofnadjust" "fnadjust")
+    (word "entitiespretty" "entitiesplain")
+    (word "title" "author" "email" "date")
+    (word "todo" "done")
+    ;; source block
+    ;; TODO
+    )))
 
 (provide 'grugru-default)
 ;;; grugru-default.el ends here


### PR DESCRIPTION
Add some default settings for org mode. Additional default settings for source blocks will be added in future.