### PR TITLE
fix: Drop deprecated :style from grugru-highlight-face

### DIFF
--- a/grugru.el
+++ b/grugru.el
@@ -1607,7 +1607,7 @@ ORIGINAL is original function.  SYMBOL, TYPE and LIBRARY is original arguments."
   :group 'grugru)
 
 (defface grugru-highlight-face
-  '((t (:box (:line-width 1 :color "#ff0000" :style nil))))
+  '((t (:box (:line-width 1 :color "#ff0000"))))
   "Face used `grugru-highlight-mode'."
   :group 'grugru)
 

--- a/grugru.el
+++ b/grugru.el
@@ -5,7 +5,7 @@
 ;; Author: ROCKTAKEY <rocktakey@gmail.com>
 ;; Keywords: convenience, abbrev, tools
 
-;; Version: 1.22.3
+;; Version: 1.22.4
 ;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/ROCKTAKEY/grugru
 


### PR DESCRIPTION
I noticed this after this recent commit:
https://github.com/emacs-mirror/emacs/commit/dcd755dabcf9ef95d6d0534c11c668f44c6f89c2